### PR TITLE
Update method privacy

### DIFF
--- a/safe_contract.sol
+++ b/safe_contract.sol
@@ -56,7 +56,7 @@ contract safeModule {
         safeCheck(msg.sender);
             // drain funds into new safe 
             // its now someone elses problem
-        executeTransferSafe(beneficiary, amount);
+        _executeTransferSafe(beneficiary, amount);
         emit ExecuteTransferSafe(safeAddress, beneficiary, amount);
     }
     // vote for transferring safe
@@ -130,7 +130,7 @@ contract safeModule {
         lastTransactionTime = block.timestamp;
     }
 
-    function executeTransferSafe(address payable to, uint96 amount) public {
+    function _executeTransferSafe(address payable to, uint96 amount) private {
         // require(creator == msg.sender, "not the same people");
         safe.execTransactionFromModule(to, amount, "", Enum.Operation.Call);
     }


### PR DESCRIPTION
Hi Alex, thanks for your submission on behalf of the Safe team.

I just wanted to highlight a security issue I found in the module:
- `transferSafe` method is public, but it should be private to ensure it's only called from another method within this contract (like `transferSafe`, where the `safeCheck` is executed), preventing that it is executed by any other account.

Keep building, ser!